### PR TITLE
Fix fallback font

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -16,7 +16,7 @@
 }
 
 .editor-colors {
-  font-family: 'Source Code Pro', 'Monospace';
+  font-family: 'Source Code Pro', monospace;
 }
 
 .editor {


### PR DESCRIPTION
Using `'Monospace'` as fallback font seems to not work properly. This PR replaces it with `monospace`.

A thing to keep in mind is that if the `font-family` is defined in a theme, people can't pick their own by entering it in the settings. I advise to remove that line and change the README to something like this:

"Quantum works best with the `Source Code Pro` font, if you have it installed you can enable it in Atom's settings by enter the name into the Font Family field".
