### PR TITLE
Fix mini-editor mutliline overflow issues.

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -6,6 +6,7 @@ atom-text-editor[mini] {
   background-color: @input-background-color;
   border-radius: @component-border-radius;
   padding-left: @component-padding / 2;
+  max-height: none;
 
   .placeholder-text {
     color: @text-color-subtle;

--- a/styles/overlays.less
+++ b/styles/overlays.less
@@ -10,7 +10,7 @@ atom-panel.modal {
 
   atom-text-editor[mini] {
     padding: @component-padding;
-    height: (32px + @component-padding);
+    min-height: (32px + @component-padding);
     max-height: 100%;
     margin: 0;
   }

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -35,7 +35,7 @@ atom-panel {
 
   atom-text-editor[mini] {
     background: rgba(0,0,0,0.1);
-    height: 27px;
+    min-height: 27px;
 
     &.is-focused .placeholder-text {
       color: @text-color;


### PR DESCRIPTION
Right now, if you try to enter a long string into a mini-editor, such as the find dialog, the content wraps to the next line, off the bottom of the viewport.

This fixes that.